### PR TITLE
External certificate handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ Options:
   -V, --version                  output the version number
   -o, --open                     Open in the browser automatically.
   -n, --host [host]              If -b flag is being used, this allows for custom host. Defaults to localhost.
-  -S, --ssl                      Start https server instead of http. Defaults to false.
   -d, --dir [dir]                The directory to serve up. Defaults to current dir.
   -w, --watch-dir [watch-dir]    The directory to watch. Defaults the serving directory.
   -e, --exts [extensions]        Extensions separated by commas or pipes. Defaults to html,js,css.
@@ -75,8 +74,13 @@ Options:
   --proxyHost [proxyhost]             Proxy requests to another server running at `host`. Requires `--proxyHost` and should be a full URL, eg. `http://localhost:9000`. Defaults to not proxying
   -s, --start-page [start-page]  Specify a start page. Defaults to index.html
   -u, --pushstate [pushstate]    Automatically serve the root or `index.html` for SPAs. Defaults to false.
+  -S, --ssl                      Start https server instead of http. Defaults to false.
+  -c, --cert [cert]              Location of an external certificate file. Requires `--ssl` and `--key`. Defaults to a self signed certificate.
+  -k, --key [key]                Location of an external certificate key file. Requires `--ssl` and `--cert`. Defaults to a self signed key.
   -v, --verbose [verbose]        Turning on logging on the server and client side. Defaults to false
 ```
+
+Any external certificate/key pair may be used. For local development, a good option for valid, self signed certificates is [mkcert](https://github.com/FiloSottile/mkcert).
 
 ## License
 

--- a/bin/elm-serve.js
+++ b/bin/elm-serve.js
@@ -54,6 +54,14 @@ program
     false
   )
   .option(
+    '-c, --cert [cert]',
+    'Location of an external certificate file. Requires `--ssl` and `--key`. Defaults to a self signed certificate.'
+  )
+  .option(
+    '-k, --key [key]',
+    'Location of an external certificate key file. Requires `--ssl` and `--cert`. Defaults to a self signed key.'
+  )
+  .option(
     '-v, --verbose [verbose]',
     'Turning on logging on the server and client side. Defaults to false',
     false

--- a/lib/elm-reload-server.js
+++ b/lib/elm-reload-server.js
@@ -21,6 +21,8 @@ const verbose = argv._[7] === 'true'
 const proxyPrefix = argv._[8]
 const proxyHost = argv._[9]
 const ssl = argv._[10] === 'true'
+const certFile = argv._[11]
+const keyFile = argv._[12]
 const ip = internalIp.v4.sync()
 const reloadOpts = {
   port: port,
@@ -106,23 +108,33 @@ function listener () {
 }
 
 if (ssl) {
-  const pem = require('pem')
-  const baseNames = [ 'localhost', '127.0.0.1' ]
-  const altNames = (ip && baseNames.indexOf(ip) === -1)
-    ? [ip, ...baseNames]
-    : baseNames
-
-  pem.createCertificate({
-    days: 1,
-    selfSigned: true,
-    commonName: ip,
-    altNames
-  }, function (err, { serviceKey, certificate }) {
-    if (err) throw new Error(err)
-    const server = https.createServer({ key: serviceKey, cert: certificate }, handler)
+  if (keyFile.length > 0 && certFile.length > 0) {
+    const options = {
+      key: fs.readFileSync(keyFile),
+      cert: fs.readFileSync(certFile)
+    }
+    const server = https.createServer(options, handler)
     reloadReturned = elmReload(reloadOpts, server)
     server.listen(port, listener)
-  })
+  } else {
+    const pem = require('pem')
+    const baseNames = [ 'localhost', '127.0.0.1' ]
+    const altNames = (ip && baseNames.indexOf(ip) === -1)
+      ? [ip, ...baseNames]
+      : baseNames
+
+    pem.createCertificate({
+      days: 1,
+      selfSigned: true,
+      commonName: ip,
+      altNames
+    }, function (err, { serviceKey, certificate }) {
+      if (err) throw new Error(err)
+      const server = https.createServer({ key: serviceKey, cert: certificate }, handler)
+      reloadReturned = elmReload(reloadOpts, server)
+      server.listen(port, listener)
+    })
+  }
 } else {
   const server = http.createServer(handler)
   reloadReturned = elmReload(reloadOpts, server)

--- a/lib/elm-serve.js
+++ b/lib/elm-serve.js
@@ -36,11 +36,21 @@ module.exports = function elmServe (opts) {
     opts.verbose || false,
     opts.proxyPrefix || false,
     opts.proxyHost || false,
-    opts.ssl || false
+    opts.ssl || false,
+    opts.cert || '',
+    opts.key || ''
   ]
 
   if ((opts.proxyPrefix && !opts.proxyHost) || (opts.proxyHost && !opts.proxyPrefix)) {
     throw new Error('If either `--proxyPrefix` and `--proxyHost` is given, the other must be as well')
+  }
+
+  if (!opts.cert || !opts.key) {
+    throw new Error('If `--cert` or `--key` is given, the other must be as well.')
+  }
+
+  if ((opts.cert && opts.key) && !opts.ssl) {
+    throw new Error('`--ssl` must be given to use `--cert` and `--key`.')
   }
 
   supervisor.run(args)

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   ],
   "author": "William King <contact@wking.io>",
   "contributors": [
-    "William King <contact@wking.io>"
+    "William King <contact@wking.io>",
+    "Tim DuBois <tim@neophilus.net>"
   ],
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
Closes #5.

Unsure if this needs additional documentation or not, but this PR will enable the use of external certificates if enabled, or fall back to the self signed ones if not.

Throws errors when `--cert` is used without `--key` and vice versa, as well as if `--cert` and `--key` are used without `--ssl`.

Complete example using [mkcert](https://github.com/FiloSottile/mkcert):

```bash
project/path $ mkcert -install
project/path $ mkcert localhost 127.0.0.1 ::1
project/path $ elm make src/Main.elm
project/path $ elm-serve -d dist -w src -c localhost+1.pem -k localhost+1-key.pem -S --open
```
