### PR TITLE
Update elm-reload-server.js to handle node v20.17.0

### DIFF
--- a/lib/elm-reload-server.js
+++ b/lib/elm-reload-server.js
@@ -90,7 +90,7 @@ function handler (req, res) {
 
 function listener () {
   if (!fs.existsSync(runFile)) {
-    fs.writeFileSync(runFile)
+    fs.writeFileSync(runFile, "")
 
     // If openBrowser, open the browser with the given start page above, at a hostname (localhost default or specified).
     if (openBrowser) {


### PR DESCRIPTION
```
TypeError [ERR_INVALID_ARG_TYPE]: The "data" argument must be of type string or an instance of Buffer, TypedArray, or DataView. Received undefined
    at Object.writeFileSync (node:fs:2376:5)
    at Server.listener (~/node_modules/elm-serve/lib/elm-reload-server.js:93:8)
```
Node.js v20.17.0